### PR TITLE
docs: activate Fase UX-Polish between Fase U and Fase 1

### DIFF
--- a/.claude/agents/frontend-dev.md
+++ b/.claude/agents/frontend-dev.md
@@ -44,6 +44,17 @@ You implement React frontend changes for finance-hledger.
 - Commit message format: `[Phase X / PR-Y] type: short description`
 - One logical change per commit.
 
+### Visual verification
+
+After implementing a UI change, verify the result in the running app — don't claim a UI task complete based on code inspection alone.
+
+- Dev server on `:5173` (Vite) or the homelab URL on `:5199`.
+- Use the chrome-devtools MCP to navigate, snapshot, and screenshot.
+- Capture at desktop (1280px) and mobile (375px) breakpoints.
+- Capture both dark and light modes.
+- Attach the screenshots to the PR description.
+- If you cannot reach a running instance (e.g. sandboxed environment), say so explicitly in the output rather than claiming visual verification happened.
+
 ## Before you start any task
 
 1. Read the PRD section for the feature you're touching.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Personal/family finance dashboard that reads from an [hledger](https://hledger.o
 
 ## Development phases
 
-This project is executed in **three sequential phases**. Always check which phase is active before making architectural decisions. **Do not skip ahead.** Phase D assumes Phase 0 is complete. Phase 1 assumes Phase D is complete.
+This project is executed in **sequential phases**. Always check which phase is active before making architectural decisions. **Do not skip ahead.** Each phase assumes the previous one is complete.
 
 ### Current phase
 
@@ -25,14 +25,20 @@ This project is executed in **three sequential phases**. Always check which phas
 - [x] Fase 0 — Estabilização (see `docs/01-ESTABILIZACAO.md`) — COMPLETED
 - [x] Fase D — Dashboard 2.0 (see `docs/02-PRD-dashboard-v2.md`) - COMPLETED
 - [x] Fase U — UI/UX (see `docs/04-PRD-ui-ux.md`) — COMPLETED
-- [ ] Fase 1 — Magic Import (see `docs/03-PRD-magic-import.md`) ← ACTIVE
+- [ ] Fase UX-Polish — post-Fase U feedback pass (see `docs/05-PRD-ux-polish.md`) ← ACTIVE
+- [ ] Fase 1 — Magic Import (see `docs/03-PRD-magic-import.md`)
 
 ### Phase boundaries
 
 - **Fase 0:** refactoring only. No new user-visible features. Target structure in §3 (backend) and §4 (frontend) of the Estabilização doc.
 - **Fase D:** dashboard rework inspired by the family's old spreadsheet (see `docs/00-DIAGNOSTICO-planilha.md`). Introduces the Principle dimension, new tab structure (Mês, Ano, Plano, Fluxo reformulado, Patrimônio, Transações). Magic Import tab is a placeholder.
 - **Fase U:** UI/UX overhaul — indigo-violet dual-mode palette, new nav (sidebar + bottom tabs), redesigned visualizations per tab. Nine PRs (U0–U9). Plano/Previsão hidden from nav during this phase.
+- **Fase UX-Polish:** bug fixes and layout corrections from daily use of the Fase U output. No new features, no new endpoints (except where a bug requires it). Tracked as a finite backlog of GitHub issues labeled `ux-polish`. Must complete before Fase 1.
 - **Fase 1:** Magic Import — AI-powered ingestion of bank statements and credit card invoices. Depends on the Principle dimension from Phase D.
+
+### Working through Fase UX-Polish issues
+
+The `ux-polish` label marks a finite backlog (see `docs/05-PRD-ux-polish.md` for the current issue index). Pick one per PR, in any order — they have no interdependencies except that the Resumo/Mês merge benefits from the card-crédito bug fix landing first so the merged tab's Cartões section works out of the box.
 
 ## Architectural decisions
 

--- a/docs/05-PRD-ux-polish.md
+++ b/docs/05-PRD-ux-polish.md
@@ -1,0 +1,54 @@
+# Fase UX-Polish — PRD
+
+Post-Fase U feedback pass. After a few days of daily use on the homelab, a set of visual and behavioural issues surfaced that need fixing before Fase 1 (Magic Import) begins. These are tracked as discrete GitHub issues rather than a staged PR plan — each can be picked up independently.
+
+## Principles
+
+- **No new features.** This phase fixes what Fase U shipped. New capability belongs to Fase 1 or a later phase.
+- **No new endpoints** unless a bug requires one. Prefer fixing a frontend filter or a formatting helper before reaching for the backend.
+- **One issue per PR.** Keeps review surface small and lets the user prioritise what lands when.
+- **Visually verify before closing.** Every PR must include screenshots at desktop + mobile, dark + light. See the `frontend-dev` agent's "Visual verification" section.
+
+## Scope — the issues
+
+The full list lives on GitHub under the `ux-polish` label: <https://github.com/lmveloso/finance-hledger/issues?q=is%3Aissue+label%3Aux-polish>
+
+As of the phase kickoff (2026-04-23), seven issues are open:
+
+| # | Area | Summary |
+|---|------|---------|
+| [#2](https://github.com/lmveloso/finance-hledger/issues/2) | Theme | Swap Instrument Serif → Google Sans Flex everywhere |
+| [#3](https://github.com/lmveloso/finance-hledger/issues/3) | Navigation | Merge Resumo + Mês into one tab with click-to-expand KPI cards |
+| [#4](https://github.com/lmveloso/finance-hledger/issues/4) | Ano | Move Metas por Princípio to Ano as a month drilldown |
+| [#5](https://github.com/lmveloso/finance-hledger/issues/5) | Bug | Credit-card section always renders empty — `tipo_movimento` mismatch |
+| [#6](https://github.com/lmveloso/finance-hledger/issues/6) | Fluxo | Split liabilities into a separate "Passivos" section |
+| [#7](https://github.com/lmveloso/finance-hledger/issues/7) | Transações | Capitalize category names (currently lowercase fallthrough) |
+| [#8](https://github.com/lmveloso/finance-hledger/issues/8) | Orçamento | Desktop: one-line per-category layout (keep mobile as-is) |
+
+## Ordering
+
+The issues have no hard dependencies. Recommended order for minimum churn:
+
+1. **#5 (credit card bug)** — one-line fix + test; unblocks the Cartões section inside the merged Mês tab.
+2. **#7 (capitalize categorias)** — backend-only data/formatting fix; lands independently.
+3. **#6 (Fluxo passivos section)** — isolated to one component.
+4. **#2 (font swap)** — touches many files but is mechanical. Do before #3/#4 so the merged tab doesn't reintroduce Instrument Serif in new code.
+5. **#4 (Metas → Ano drilldown)** — needed before #3 so the merged Mês tab can drop Metas without losing the data surface.
+6. **#8 (Orçamento desktop)** — isolated to one feature folder.
+7. **#3 (Resumo + Mês merge)** — the largest change; lands last to benefit from #2, #4, #5.
+
+The user may re-order based on priority; this is guidance, not a dependency graph.
+
+## Exit criteria
+
+- All seven issues above closed (or moved out of the phase with written justification on this doc).
+- `grep -rn "Instrument" frontend/` returns zero matches.
+- A smoke pass on the running app (desktop + mobile, dark + light) shows no visible regressions against the pre-polish state.
+- `CLAUDE.md` "Current phase" block updated to mark this phase complete and Fase 1 active.
+
+## Out of scope
+
+- New Plano / Previsão tabs. Both stay hidden until Fase 1 or later.
+- Accessibility / ARIA audit beyond per-issue requirements.
+- Performance / bundle-size work. That's [#1](https://github.com/lmveloso/finance-hledger/issues/1), tracked separately.
+- Anything that requires a new ADR. If you hit that, stop and write the ADR under `docs/adr/` first.


### PR DESCRIPTION
## Summary

- Activate **Fase UX-Polish** as a finite, post-Fase U feedback pass; Fase 1 (Magic Import) queues behind it.
- Add `docs/05-PRD-ux-polish.md` indexing the seven GitHub issues tagged `ux-polish` (#2, #3, #4, #5, #6, #7, #8) and recommending an implementation order.
- Add a **Visual verification** section to the `frontend-dev` subagent so UI changes require running-app screenshots (desktop + mobile, dark + light) before being declared complete.

## Test plan

- [ ] `CLAUDE.md` "Current phase" shows Fase UX-Polish as ACTIVE and Fase 1 as queued.
- [ ] `docs/05-PRD-ux-polish.md` links to all seven `ux-polish` issues.
- [ ] `.claude/agents/frontend-dev.md` Visual verification section is reachable by the agent at session start.