### PR TITLE
[Fase UX-Polish / PR-P1] Fix empty Cartões section on Mês (closes #5)

### DIFF
--- a/frontend/src/features/mes/hooks/__tests__/useCreditCards.test.js
+++ b/frontend/src/features/mes/hooks/__tests__/useCreditCards.test.js
@@ -1,0 +1,142 @@
+// Unit tests for `aggregateCard` (the pure aggregation helper behind
+// `useCreditCards`). Covers the tipo_movimento contract fix from issue #5:
+// the backend tags card purchases as 'debito' (liability-side valor is
+// negative), and the aggregator must flip the sign so totals read as
+// positive spend.
+//
+// Style matches frontend/src/features/fluxo-reformado/lib/__tests__/
+// waterfall.test.js — Vitest conventions, no React / DOM rendering.
+
+import { describe, it, expect } from 'vitest';
+import { aggregateCard } from '../useCreditCards.js';
+
+const palette = ['#111', '#222', '#333', '#444'];
+const CARD = 'liabilities:cartao:nubank';
+
+function tx(overrides) {
+  return {
+    data: '2026-04-01',
+    descricao: 'test',
+    conta: CARD,
+    valor: 0,
+    contra_conta: '',
+    categoria: '',
+    tipo_movimento: 'debito',
+    ...overrides,
+  };
+}
+
+function agg(transactions) {
+  return aggregateCard(CARD, 'Nubank', { transactions }, palette);
+}
+
+describe('aggregateCard', () => {
+  it('includes debito purchases and flips sign to positive', () => {
+    const out = agg([
+      tx({
+        tipo_movimento: 'debito',
+        valor: -150,
+        contra_conta: 'expenses:alimentacao:mercado',
+      }),
+    ]);
+    expect(out.total).toBe(150);
+    expect(out.categories).toHaveLength(1);
+    expect(out.categories[0].raw).toBe('alimentacao');
+    expect(out.categories[0].valor).toBe(150);
+  });
+
+  it('still includes credito entries (e.g. refunds) against an expense account', () => {
+    const out = agg([
+      tx({
+        tipo_movimento: 'credito',
+        valor: 40,
+        contra_conta: 'expenses:lazer:streaming',
+      }),
+    ]);
+    expect(out.total).toBe(40);
+    expect(out.categories).toHaveLength(1);
+    expect(out.categories[0].raw).toBe('lazer');
+    expect(out.categories[0].valor).toBe(40);
+  });
+
+  it('excludes transfers whose contra starts with assets: or liabilities:', () => {
+    const out = agg([
+      tx({
+        tipo_movimento: 'credito',
+        valor: 500,
+        contra_conta: 'assets:banco:corrente',
+      }),
+      tx({
+        tipo_movimento: 'credito',
+        valor: 200,
+        contra_conta: 'liabilities:cartao:outro',
+      }),
+    ]);
+    expect(out.total).toBe(0);
+    expect(out.categories).toEqual([]);
+    expect(out.transactions).toEqual([]);
+  });
+
+  it('excludes saldo_inicial entries', () => {
+    const out = agg([
+      tx({
+        tipo_movimento: 'saldo_inicial',
+        valor: -1200,
+        contra_conta: 'equity:saldo-inicial',
+      }),
+    ]);
+    expect(out.total).toBe(0);
+    expect(out.categories).toEqual([]);
+  });
+
+  it('sums purchases per L1 category segment', () => {
+    const out = agg([
+      tx({
+        tipo_movimento: 'debito',
+        valor: -80,
+        contra_conta: 'expenses:saude:farmacia',
+      }),
+      tx({
+        tipo_movimento: 'debito',
+        valor: -220,
+        contra_conta: 'expenses:saude:medico',
+      }),
+      tx({
+        tipo_movimento: 'debito',
+        valor: -50,
+        contra_conta: 'expenses:lazer:cinema',
+      }),
+    ]);
+    expect(out.total).toBe(350);
+    const saude = out.categories.find((c) => c.raw === 'saude');
+    const lazer = out.categories.find((c) => c.raw === 'lazer');
+    expect(saude.valor).toBe(300);
+    expect(lazer.valor).toBe(50);
+    // sorted descending by valor
+    expect(out.categories[0].raw).toBe('saude');
+    expect(out.categories[1].raw).toBe('lazer');
+  });
+
+  it('produces total === 0 for a card with zero qualifying purchases', () => {
+    const out = agg([]);
+    expect(out.total).toBe(0);
+    expect(out.categories).toEqual([]);
+    expect(out.transactions).toEqual([]);
+  });
+
+  it('produces total === 0 when only transfers and saldo_inicial are present', () => {
+    const out = agg([
+      tx({
+        tipo_movimento: 'credito',
+        valor: 1000,
+        contra_conta: 'assets:banco:corrente',
+      }),
+      tx({
+        tipo_movimento: 'saldo_inicial',
+        valor: -500,
+        contra_conta: 'equity:saldo-inicial',
+      }),
+    ]);
+    expect(out.total).toBe(0);
+  });
+});

--- a/frontend/src/features/mes/hooks/useCreditCards.js
+++ b/frontend/src/features/mes/hooks/useCreditCards.js
@@ -4,9 +4,16 @@
 //   1. Fetch /api/flow?month=YYYY-MM and filter to liability card accounts.
 //   2. For each discovered card, parallel-fetch /api/transactions with
 //      account=<card>&limit=500.
-//   3. Aggregate per card client-side: purchases only (tipo_movimento ===
-//      'credito' AND contra_conta starts with 'expenses:'), grouped by L1
-//      category (second segment of the expense account path).
+//   3. Aggregate per card client-side: purchases only (contra_conta starts
+//      with 'expenses:'), grouped by L1 category (second segment of the
+//      expense account path).
+//
+// Note on tipo_movimento (issue #5): from the card's (liability) perspective,
+// a purchase posts a NEGATIVE valor (balance grows more negative), so the
+// backend tags it as 'debito'. A refund/chargeback posts a POSITIVE valor
+// and is tagged 'credito'. We keep both here — anything whose contra-posting
+// lands in `expenses:` is a card activity we want to aggregate — and take
+// the absolute value so totals read as positive spend.
 //
 // Output shape:
 //   {
@@ -78,20 +85,26 @@ async function fetchJson(path) {
   return r.json();
 }
 
-function aggregateCard(conta, nome, txResponse, palette) {
+export function aggregateCard(conta, nome, txResponse, palette) {
   const all = Array.isArray(txResponse?.transactions)
     ? txResponse.transactions
     : [];
-  // Purchases only: the liability shows tipo_movimento='credito' with the
-  // contra posting going to an expense account.
+  // Purchases: contra-posting lands in an expense account. Backend tags these
+  // as 'debito' (negative valor on the liability) for a real purchase or
+  // 'credito' (positive valor) for a refund/chargeback. Both are card
+  // activity we want to surface. Transfers (contra starts with 'assets:' /
+  // 'liabilities:') and opening balances ('saldo_inicial') are excluded by
+  // the expense-prefix test; we still check tipo_movimento to be defensive.
   const purchases = all.filter(
     (tx) =>
-      tx.tipo_movimento === 'credito' &&
+      (tx.tipo_movimento === 'debito' || tx.tipo_movimento === 'credito') &&
       typeof tx.contra_conta === 'string' &&
       tx.contra_conta.startsWith('expenses:'),
   );
 
-  const total = purchases.reduce((s, tx) => s + (tx.valor || 0), 0);
+  // Flip sign so aggregates read as positive spend regardless of the
+  // liability-side sign convention.
+  const total = purchases.reduce((s, tx) => s + Math.abs(tx.valor || 0), 0);
 
   // Group by L1 category (second segment of 'expenses:<l1>:...').
   const byCategory = new Map();
@@ -99,7 +112,7 @@ function aggregateCard(conta, nome, txResponse, palette) {
     const parts = (tx.contra_conta || '').split(':');
     const raw = parts[1] || 'outros';
     const prev = byCategory.get(raw) || { raw, valor: 0 };
-    prev.valor += tx.valor || 0;
+    prev.valor += Math.abs(tx.valor || 0);
     byCategory.set(raw, prev);
   }
 


### PR DESCRIPTION
## Summary

- Fix credit-card section on Mês tab always rendering empty due to `tipo_movimento` filter mismatch with the backend classifier.
- Accept both `debito` and `credito` for transactions whose contra starts with `expenses:`, then sign-flip with `Math.abs` so totals are positive.
- Add Vitest coverage for the `aggregateCard` pure helper (7 cases).

## Root cause

Backend `_transactions_for_account` tags liability-side purchases as `debito` (valor < 0 on the card account). The frontend hook accepted only `credito`, so every card rendered with `total === 0` and was filtered out.

## Test plan

- [x] `npx vitest run src/features/mes/hooks/__tests__/useCreditCards.test.js` — 7/7 pass.
- [ ] Manual verification on homelab: April 2026 Mês tab shows at least `xp-visa` with real purchases grouped by L1 category (desktop + mobile, dark + light).
- [ ] Confirm card with zero purchases in the month remains hidden.
- [ ] Confirm transfers (card payments from assets) are still excluded.

Closes #5.