### PR TITLE
[Fase UX-Polish / PR-P3] Split Fluxo Contas grid into Ativos / Passivos (#6)

### DIFF
--- a/frontend/src/features/fluxo-reformado/components/AccountCards.jsx
+++ b/frontend/src/features/fluxo-reformado/components/AccountCards.jsx
@@ -25,9 +25,12 @@ const BRL = (n) =>
  * Uses CSS Grid `repeat(auto-fit, minmax(220px, 1fr))` for responsive wrap.
  */
 function AccountCards({ contas }) {
-  const sorted = useMemo(() => sortAccounts(contas || []), [contas]);
+  const { ativos, passivos } = useMemo(
+    () => partitionAccounts(contas || []),
+    [contas],
+  );
 
-  if (sorted.length === 0) return null;
+  if (ativos.length === 0 && passivos.length === 0) return null;
 
   return (
     <div>
@@ -43,22 +46,69 @@ function AccountCards({ contas }) {
       >
         {t('fluxo.contas.title')}
       </div>
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
-          gap: 12,
-        }}
-      >
-        {sorted.map((c) => (
-          <AccountCard key={c.conta} conta={c} />
-        ))}
-      </div>
+
+      {ativos.length > 0 && (
+        <div>
+          <div
+            className="sans"
+            style={{
+              fontSize: 10,
+              color: color.text.muted,
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+              marginBottom: 8,
+              marginTop: 4,
+            }}
+          >
+            {t('fluxo.contas.sectionAtivos')}
+          </div>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+              gap: 12,
+            }}
+          >
+            {ativos.map((c) => (
+              <AccountCard key={c.conta} conta={c} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {passivos.length > 0 && (
+        <div style={{ marginTop: 20 }}>
+          <div
+            className="sans"
+            style={{
+              fontSize: 10,
+              color: color.text.muted,
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+              marginBottom: 8,
+              marginTop: 4,
+            }}
+          >
+            {t('fluxo.contas.sectionPassivos')}
+          </div>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+              gap: 12,
+            }}
+          >
+            {passivos.map((c) => (
+              <AccountCard key={c.conta} conta={c} />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
 
-function sortAccounts(contas) {
+function partitionAccounts(contas) {
   const ativos = contas
     .filter((c) => c.tipo === 'ativo')
     .slice()
@@ -71,7 +121,7 @@ function sortAccounts(contas) {
         Math.abs((b.saldo_final ?? 0) - (b.saldo_inicial ?? 0)) -
         Math.abs((a.saldo_final ?? 0) - (a.saldo_inicial ?? 0)),
     );
-  return [...ativos, ...passivos];
+  return { ativos, passivos };
 }
 
 function AccountCard({ conta }) {

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -109,6 +109,8 @@ const dict = {
   'fluxo.waterfall.footnote.suffix': '.',
   'fluxo.movimentos.title': 'Movements per account',
   'fluxo.contas.title': 'Accounts',
+  'fluxo.contas.sectionAtivos': 'Assets',
+  'fluxo.contas.sectionPassivos': 'Liabilities · cards',
   'fluxo.contas.tipo_ativo': 'Asset',
   'fluxo.contas.tipo_passivo': 'Liability',
   'fluxo.contas.entradas': 'Inflow',

--- a/frontend/src/i18n/pt-BR.js
+++ b/frontend/src/i18n/pt-BR.js
@@ -112,6 +112,8 @@ const dict = {
   'fluxo.waterfall.footnote.suffix': '.',
   'fluxo.movimentos.title': 'Movimentos por conta',
   'fluxo.contas.title': 'Contas',
+  'fluxo.contas.sectionAtivos': 'Ativos',
+  'fluxo.contas.sectionPassivos': 'Passivos · cartões',
   'fluxo.contas.tipo_ativo': 'Ativo',
   'fluxo.contas.tipo_passivo': 'Passivo',
   'fluxo.contas.entradas': 'Entradas',


### PR DESCRIPTION
## Summary

- Split the Fluxo tab's Contas grid into two labelled sub-sections (Ativos / Passivos · cartões).
- Card markup, delta logic, colors, and sort orders preserved — purely a render restructure.
- Passivos section header hidden when there are no liability accounts for the month.
- i18n keys added in both pt-BR and en.

## Test plan

- [x] `npm run build` — clean, no new warnings.
- [ ] Manual: open Fluxo tab on homelab, confirm two sections render correctly (desktop 1280px + mobile 375px, dark + light).
- [ ] Confirm a month with no liability activity hides the Passivos section entirely.

Closes #6.