### PR TITLE
[Fase UX-Polish / PR-P4] Swap Instrument Serif for Google Sans Flex (#2)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,8 @@
     <link rel="apple-touch-icon" href="/icon-192.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Instrument+Serif:ital@0;1&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" />
+    <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Flex:opsz,wght@8..144,100..1000&display=swap" rel="stylesheet">
     <title>Finanças Pessoais</title>
   </head>
   <body style="margin:0;background:#0d0f1a;">

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -120,7 +120,7 @@ function AppInner() {
     @keyframes spin { to { transform: rotate(360deg); } }
     * { box-sizing: border-box; margin: 0; }
     body { background: ${tokens.bg.page}; }
-    .serif { font-family: 'Instrument Serif', Georgia, serif; }
+    .serif { font-family: 'Google Sans Flex', 'Plus Jakarta Sans', system-ui, sans-serif; }
     .sans { font-family: 'Plus Jakarta Sans', system-ui, sans-serif; }
     .card { background: ${tokens.bg.card}; border: 1px solid ${tokens.border.default}; border-radius: 4px; padding: 24px; }
     .tab { padding: 10px 16px; cursor: pointer; border: none; background: transparent; color: ${tokens.text.muted}; font-family: 'Plus Jakarta Sans', system-ui, sans-serif; font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; border-bottom: 2px solid transparent; transition: all 0.15s; }

--- a/frontend/src/features/ano/components/MatrixTable.jsx
+++ b/frontend/src/features/ano/components/MatrixTable.jsx
@@ -52,7 +52,7 @@ function MatrixTable({ months, rows, totals, showPct = false }) {
     textAlign: 'right',
     padding: '6px 8px',
     borderBottom: `1px solid ${color.border.subtle}`,
-    fontFamily: "'Instrument Serif', Georgia, serif",
+    fontFamily: "'Google Sans Flex', 'Plus Jakarta Sans', system-ui, sans-serif",
     fontSize: 12,
     color: color.text.primary,
     whiteSpace: 'nowrap',

--- a/frontend/src/features/fluxo-reformado/components/MovimentosTable.jsx
+++ b/frontend/src/features/fluxo-reformado/components/MovimentosTable.jsx
@@ -103,7 +103,7 @@ const td = (align) => ({
   padding: '10px',
   borderBottom: `1px solid ${color.border.subtle}`,
   color: color.text.secondary,
-  fontFamily: align === 'right' ? "'Instrument Serif', Georgia, serif" : "'Plus Jakarta Sans', system-ui, sans-serif",
+  fontFamily: align === 'right' ? "'Google Sans Flex', 'Plus Jakarta Sans', system-ui, sans-serif" : "'Plus Jakarta Sans', system-ui, sans-serif",
   whiteSpace: 'nowrap',
 });
 

--- a/frontend/src/features/orcamento/components/CategoryRow.jsx
+++ b/frontend/src/features/orcamento/components/CategoryRow.jsx
@@ -93,7 +93,7 @@ function CategoryRow({ nome, orcado, realizado, barColor, isLast }) {
   const realizadoText = (
     <span
       style={{
-        fontFamily: "'Instrument Serif', Georgia, serif",
+        fontFamily: "'Google Sans Flex', 'Plus Jakarta Sans', system-ui, sans-serif",
         fontSize: 14,
         color: over ? color.feedback.negative : color.text.primary,
       }}

--- a/frontend/src/features/orcamento/components/TotalHeroCard.jsx
+++ b/frontend/src/features/orcamento/components/TotalHeroCard.jsx
@@ -91,7 +91,7 @@ function TotalHeroCard({ total }) {
           <div style={{ display: 'flex', alignItems: 'baseline', gap: 12, flexWrap: 'wrap' }}>
             <span
               style={{
-                fontFamily: "'Instrument Serif', Georgia, serif",
+                fontFamily: "'Google Sans Flex', 'Plus Jakarta Sans', system-ui, sans-serif",
                 fontSize: 36,
                 color: over ? color.feedback.negative : color.text.primary,
                 letterSpacing: '-0.02em',

--- a/frontend/src/features/patrimonio/components/AccountTransactionsTable.jsx
+++ b/frontend/src/features/patrimonio/components/AccountTransactionsTable.jsx
@@ -65,7 +65,7 @@ function AccountTransactionsTable({ transactions, withBalance = false }) {
                 <td
                   style={{
                     ...tdStyle, textAlign: 'right',
-                    fontFamily: "'Instrument Serif', Georgia, serif",
+                    fontFamily: "'Google Sans Flex', 'Plus Jakarta Sans', system-ui, sans-serif",
                     fontWeight: 600, color: valorColor,
                   }}
                 >
@@ -75,7 +75,7 @@ function AccountTransactionsTable({ transactions, withBalance = false }) {
                   <td
                     style={{
                       ...tdStyle, textAlign: 'right',
-                      fontFamily: "'Instrument Serif', Georgia, serif", fontWeight: 600,
+                      fontFamily: "'Google Sans Flex', 'Plus Jakarta Sans', system-ui, sans-serif", fontWeight: 600,
                       color: tx.runningBalance < 0 ? color.feedback.negative : color.feedback.positive,
                     }}
                   >

--- a/frontend/src/features/plano/components/ForecastTable.jsx
+++ b/frontend/src/features/plano/components/ForecastTable.jsx
@@ -56,7 +56,7 @@ function ForecastTable({ months }) {
     textAlign: 'right',
     padding: '6px 8px',
     borderBottom: `1px solid ${color.border.subtle}`,
-    fontFamily: "'Instrument Serif', Georgia, serif",
+    fontFamily: "'Google Sans Flex', 'Plus Jakarta Sans', system-ui, sans-serif",
     fontSize: 12,
     color: color.text.primary,
     whiteSpace: 'nowrap',

--- a/frontend/src/features/previsao/Previsao.jsx
+++ b/frontend/src/features/previsao/Previsao.jsx
@@ -149,7 +149,7 @@ function Previsao() {
                             textAlign: 'right',
                             padding: '6px 8px',
                             borderBottom: `1px solid ${color.border.subtle}`,
-                            fontFamily: "'Instrument Serif', Georgia, serif",
+                            fontFamily: "'Google Sans Flex', 'Plus Jakarta Sans', system-ui, sans-serif",
                             fontSize: 12,
                             color: color.text.primary,
                             // Heat-map fill: data-driven alpha. Previsão is hidden from nav in Fase U

--- a/frontend/src/theme/tokens.js
+++ b/frontend/src/theme/tokens.js
@@ -242,7 +242,7 @@ export function getModeTokens(mode) {
 export const fonts = {
   jakarta: {
     body:    "'Plus Jakarta Sans', system-ui, sans-serif",
-    display: "'Instrument Serif', Georgia, serif",
+    display: "'Google Sans Flex', 'Plus Jakarta Sans', system-ui, sans-serif",
     label:   'Jakarta',
   },
 };


### PR DESCRIPTION
## Summary

- Replace Instrument Serif with Google Sans Flex (variable font) across all 11 usages in 10 files.
- `fonts.jakarta.display` token value updated; key and `.serif` selector names preserved to keep the diff mechanical.
- Variable-axis Google Fonts link added to \`index.html\` alongside the existing Plus Jakarta Sans link.

## Test plan

- [x] \`grep -rn "Instrument" frontend/\` returns zero matches.
- [x] \`npm run build\` succeeds.
- [ ] Manual verification on homelab: check numeric columns across Mês / Ano / Fluxo / Patrimônio / Transações / Orçamento (dark + light, desktop + mobile). Confirm no layout shift or alignment regression.

## Out of scope (follow-ups)

- Renaming \`.serif\` class and \`fonts.jakarta.display\` token (now misnomers) — can be done alongside a type-scale refactor.
- Adding \`font-variant-numeric: tabular-nums\` to numeric columns if alignment regressions appear post-merge.

Closes #2.